### PR TITLE
add-multi-turn-chat-and-memory

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,58 @@
+Prompt Pilot — RAG-Powered Local LLM Chatbot
+
+**Prompt Pilot** is a local-first, extensible assistant designed to answer your questions by retrieving and reasoning over your own documents using state-of-the-art open-source language models.
+
+##  Current Features
+
+-  **PDF Document Ingestion**
+  - Loads and chunks PDF files into manageable sections for semantic search.
+
+-  **Embeddings with HuggingFace**
+  - Uses `all-MiniLM-L6-v2` to embed text chunks into vector space for similarity search.
+
+-  **Vector Indexing via LlamaIndex**
+  - Fast vector search with in-memory retrieval. Supports pluggable backends like FAISS/Chroma (planned).
+
+-  **Local LLM (Mistral 7B Instruct)**
+  - Integrated via `llama-cpp-python` and wrapped using LlamaIndex’s `LlamaCPP`.
+  - No API keys or external services — runs fully offline.
+
+-  **Retrieval-Augmented Generation (RAG)**
+  - Retrieves relevant chunks and generates context-aware answers using a local decoder-only LLM.
+
+-  **Multi-Turn Chat with Memory**
+  - Track and retain chat history to enable contextual, ongoing conversations.
+##  Upcoming Features
+
+
+-  **LoRA Fine-Tuning**
+  - Apply lightweight fine-tuning to control the assistant’s tone and behavior.
+
+-  **Observability and Logging**
+  - Log prompts, token usage, latency, and errors. Visualize with Prometheus + Grafana.
+
+-  **Web-Based Chat UI**
+  - Build an interactive UI using Next.js with PDF upload and real-time response streaming.
+
+-  **Multimodal Support (Optional)**
+  - Extend ingestion to images (OCR), audio (Whisper), and video (YouTube transcripts).
+
+##  Tech Stack
+
+- Python, HuggingFace, LlamaIndex, `llama-cpp-python`
+- Mistral 7B (GGUF format, quantized)
+- Redis / FAISS (planned)
+- Prometheus + Grafana (planned)
+- Next.js frontend (planned)
+
+##  Vision
+
+To build a completely offline, privacy-friendly **multimodal assistant** that:
+- Understands and answers questions over private documents
+- Supports RAG-based QA + memory
+- Can be fine-tuned for personality/tone via LoRA
+- Optionally handles multimodal data inputs
+
+---
+
+###  Project Status: In Progress

--- a/ingest_doc.py
+++ b/ingest_doc.py
@@ -3,6 +3,7 @@ from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.readers.file import PDFReader
 from llama_index.llms.llama_cpp import LlamaCPP
 from llama_index.core import Settings
+from llama_index.core.chat_engine import CondenseQuestionChatEngine
 
 import os
 
@@ -12,6 +13,8 @@ import os
 
 from llama_cpp import Llama
 
+
+# Initialize the LLM
 model_path = "C:/Users/sshau/.cache/huggingface/hub/models--TheBloke--Mistral-7B-Instruct-v0.1-GGUF/snapshots/731a9fc8f06f5f5e2db8a0cf9d256197eb6e05d1/mistral-7b-instruct-v0.1.Q2_K.gguf"
 
 llm = LlamaCPP(
@@ -19,19 +22,30 @@ llm = LlamaCPP(
     max_new_tokens=512,
     temperature=0.7,
 )
-# Step 1: Load your PDF
+
+# Set the embedding model globally
+Settings.embed_model = HuggingFaceEmbedding(model_name="all-MiniLM-L6-v2")
+Settings.llm = llm
+
+
+
 pdf_path = os.path.join("docs", "example.pdf")
 documents = PDFReader().load_data(file=pdf_path)
 
 
-# Step 2: Set the embedding model globally
-Settings.embed_model = HuggingFaceEmbedding(model_name="all-MiniLM-L6-v2")
-Settings.llm = llm
-# Step 3: Build vector index
+#  Build vector index
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine(llm)
+chat_engine = CondenseQuestionChatEngine.from_defaults(
+     query_engine=query_engine
+)
 
-# Step 4: Semantic query
-query_engine = index.as_query_engine(llm=None)
 
-results = query_engine.query("What is the return policy?")
-print(results)
+
+print("🧠 PromptPilot is ready! Type 'exit' to quit.")
+while True:
+    user_input = input("You: ")
+    if user_input.lower() in ["exit", "quit"]:
+        break
+    response = chat_engine.chat(user_input)
+    print(f" PromptPilot: {response.response}")


### PR DESCRIPTION
Created a Multi-Turn Chat Engine
Maintains chat history across turns

Automatically condenses follow-up questions 

Forwards the full query to the RAG pipeline